### PR TITLE
Use inner functions to reduce code re-use in Indexer.save_on_disk()

### DIFF
--- a/indexer.py
+++ b/indexer.py
@@ -46,13 +46,9 @@ class Indexer(object):
     
     def save_on_disk(self, index_dir):
 
-        def open_writeable_file(file_name):
-            file_path = os.path.join(index_dir, file_name)
-            return open(file_path, "w")
-
         def dump_json_to_file(source, file_name):
-            writeable_file = open_writeable_file(file_name)
-            json.dump(source, writeable_file, indent=4)
+            file_path = os.path.join(index_dir, file_name)
+            json.dump(source, open(file_path, "w"), indent=4)
 
         dump_json_to_file(self.inverted_index, "inverted_index")
         dump_json_to_file(self.forward_index, "forward_index")


### PR DESCRIPTION
The inner functions were less general than I might otherwise right, since they were both used for a specific purpose for a specific function. Seemed pointless to have extra parameters. Can easily be changed (especially with its limited scope) if the need arises.  Couldn't think of a way to iterate through member variables to assign stuff to them.
